### PR TITLE
Introduce the "Relayable" entity

### DIFF
--- a/lib/diaspora_federation/entities.rb
+++ b/lib/diaspora_federation/entities.rb
@@ -8,6 +8,7 @@ module DiasporaFederation
   end
 end
 
+require "diaspora_federation/entities/relayable"
 require "diaspora_federation/entities/profile"
 require "diaspora_federation/entities/person"
 require "diaspora_federation/entities/location"

--- a/lib/diaspora_federation/entities/comment.rb
+++ b/lib/diaspora_federation/entities/comment.rb
@@ -2,9 +2,7 @@ module DiasporaFederation
   module Entities
     class Comment < Entity
       property :guid
-      property :parent_guid
-      property :parent_author_signature
-      property :author_signature
+      include Relayable
       property :text
       property :diaspora_id, xml_name: :diaspora_handle
     end

--- a/lib/diaspora_federation/entities/like.rb
+++ b/lib/diaspora_federation/entities/like.rb
@@ -4,9 +4,7 @@ module DiasporaFederation
       property :positive
       property :guid
       property :target_type
-      property :parent_guid
-      property :parent_author_signature
-      property :author_signature
+      include Relayable
       property :diaspora_id, xml_name: :diaspora_handle
     end
   end

--- a/lib/diaspora_federation/entities/message.rb
+++ b/lib/diaspora_federation/entities/message.rb
@@ -2,9 +2,7 @@ module DiasporaFederation
   module Entities
     class Message < Entity
       property :guid
-      property :parent_guid
-      property :parent_author_signature
-      property :author_signature
+      include Relayable
       property :text
       property :created_at, default: -> { Time.now.utc }
       property :diaspora_id, xml_name: :diaspora_handle

--- a/lib/diaspora_federation/entities/participation.rb
+++ b/lib/diaspora_federation/entities/participation.rb
@@ -3,9 +3,7 @@ module DiasporaFederation
     class Participation < Entity
       property :guid
       property :target_type
-      property :parent_guid
-      property :parent_author_signature
-      property :author_signature
+      include Relayable
       property :diaspora_id, xml_name: :diaspora_handle
     end
   end

--- a/lib/diaspora_federation/entities/poll_participation.rb
+++ b/lib/diaspora_federation/entities/poll_participation.rb
@@ -2,8 +2,7 @@ module DiasporaFederation
   module Entities
     class PollParticipation < Entity
       property :guid
-      property :parent_guid
-      property :parent_author_signature
+      include Relayable
       property :diaspora_id, xml_name: :diaspora_handle
       property :poll_answer_guid
     end

--- a/lib/diaspora_federation/entities/relayable.rb
+++ b/lib/diaspora_federation/entities/relayable.rb
@@ -1,0 +1,13 @@
+module DiasporaFederation
+  module Entities
+    module Relayable
+      def self.included(model)
+        model.class_eval do
+          property :parent_guid
+          property :parent_author_signature
+          property :author_signature
+        end
+      end
+    end
+  end
+end

--- a/lib/diaspora_federation/validators.rb
+++ b/lib/diaspora_federation/validators.rb
@@ -34,6 +34,7 @@ module DiasporaFederation
   end
 end
 
+require "diaspora_federation/validators/relayable_validator"
 require "diaspora_federation/validators/h_card_validator"
 require "diaspora_federation/validators/person_validator"
 require "diaspora_federation/validators/profile_validator"

--- a/lib/diaspora_federation/validators/comment_validator.rb
+++ b/lib/diaspora_federation/validators/comment_validator.rb
@@ -5,11 +5,7 @@ module DiasporaFederation
 
       rule :guid, :guid
 
-      rule :parent_guid, :guid
-
-      rule :parent_author_signature, :not_empty
-
-      rule :author_signature, :not_empty
+      include RelayableValidator
 
       rule :text, [:not_empty,
                    length: {maximum: 65_535}]

--- a/lib/diaspora_federation/validators/like_validator.rb
+++ b/lib/diaspora_federation/validators/like_validator.rb
@@ -5,11 +5,7 @@ module DiasporaFederation
 
       rule :guid, :guid
 
-      rule :parent_guid, :guid
-
-      rule :parent_author_signature, :not_empty
-
-      rule :author_signature, :not_empty
+      include RelayableValidator
 
       rule :diaspora_id, %i(not_empty diaspora_id)
     end

--- a/lib/diaspora_federation/validators/message_validator.rb
+++ b/lib/diaspora_federation/validators/message_validator.rb
@@ -5,11 +5,7 @@ module DiasporaFederation
 
       rule :guid, :guid
 
-      rule :parent_guid, :guid
-
-      rule :parent_author_signature, :not_empty
-
-      rule :author_signature, :not_empty
+      include RelayableValidator
 
       rule :diaspora_id, %i(not_empty diaspora_id)
 

--- a/lib/diaspora_federation/validators/participation_validator.rb
+++ b/lib/diaspora_federation/validators/participation_validator.rb
@@ -7,11 +7,7 @@ module DiasporaFederation
 
       rule :target_type, :not_empty
 
-      rule :parent_guid, :guid
-
-      rule :parent_author_signature, :not_empty
-
-      rule :author_signature, :not_empty
+      include RelayableValidator
 
       rule :diaspora_id, %i(not_empty diaspora_id)
     end

--- a/lib/diaspora_federation/validators/poll_participation_validator.rb
+++ b/lib/diaspora_federation/validators/poll_participation_validator.rb
@@ -5,9 +5,7 @@ module DiasporaFederation
 
       rule :guid, :guid
 
-      rule :parent_guid, :guid
-
-      rule :parent_author_signature, :not_empty
+      include RelayableValidator
 
       rule :diaspora_id, %i(not_empty diaspora_id)
 

--- a/lib/diaspora_federation/validators/relayable_validator.rb
+++ b/lib/diaspora_federation/validators/relayable_validator.rb
@@ -1,0 +1,11 @@
+module DiasporaFederation
+  module Validators
+    module RelayableValidator
+      def self.included(model)
+        model.class_eval do
+          rule :parent_guid, :guid
+        end
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -93,13 +93,16 @@ FactoryGirl.define do
     width 800
   end
 
-  factory :participation_entity, class: DiasporaFederation::Entities::Participation do
-    guid
-    target_type "StatusMessage"
+  factory :relayable_entity, class: DiasporaFederation::Entities::Relayable do
     parent_guid { generate(:guid) }
-    diaspora_id
     parent_author_signature { generate(:signature) }
     author_signature { generate(:signature) }
+  end
+
+  factory :participation_entity, class: DiasporaFederation::Entities::Participation, parent: :relayable_entity do
+    guid
+    target_type "StatusMessage"
+    diaspora_id
   end
 
   factory :status_message_entity, class: DiasporaFederation::Entities::StatusMessage do
@@ -115,22 +118,16 @@ FactoryGirl.define do
     recipient_id { generate(:diaspora_id) }
   end
 
-  factory :comment_entity, class: DiasporaFederation::Entities::Comment do
+  factory :comment_entity, class: DiasporaFederation::Entities::Comment, parent: :relayable_entity do
     guid
-    parent_guid { generate(:guid) }
-    parent_author_signature { generate(:signature) }
-    author_signature { generate(:signature) }
     text "this is a very informative comment"
     diaspora_id
   end
 
-  factory :like_entity, class: DiasporaFederation::Entities::Like do
+  factory :like_entity, class: DiasporaFederation::Entities::Like, parent: :relayable_entity do
     positive 1
     guid
     target_type "StatusMessage"
-    parent_guid { generate(:guid) }
-    parent_author_signature { generate(:signature) }
-    author_signature { generate(:signature) }
     diaspora_id
   end
 
@@ -147,11 +144,8 @@ FactoryGirl.define do
     participant_ids { 3.times.map { generate(:diaspora_id) }.join(";") }
   end
 
-  factory :message_entity, class: DiasporaFederation::Entities::Message do
+  factory :message_entity, class: DiasporaFederation::Entities::Message, parent: :relayable_entity do
     guid
-    parent_guid { generate(:guid) }
-    parent_author_signature { generate(:signature) }
-    author_signature { generate(:signature) }
     text "this is a very informative text"
     created_at { DateTime.now.utc }
     diaspora_id
@@ -200,11 +194,11 @@ FactoryGirl.define do
     poll_answers { 3.times.map { FactoryGirl.build(:poll_answer_entity) } }
   end
 
-  factory :poll_participation_entity, class: DiasporaFederation::Entities::PollParticipation do
+  factory :poll_participation_entity,
+          class:  DiasporaFederation::Entities::PollParticipation,
+          parent: :relayable_entity do
     guid
-    parent_guid { generate(:guid) }
     diaspora_id
-    parent_author_signature { generate(:signature) }
     poll_answer_guid { generate(:guid) }
   end
 end

--- a/spec/lib/diaspora_federation/entities/conversation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/conversation_spec.rb
@@ -15,26 +15,7 @@ module DiasporaFederation
   <guid>#{data[:guid]}</guid>
   <subject>#{data[:subject]}</subject>
   <created_at>#{data[:created_at]}</created_at>
-  <message>
-    <guid>#{msg1.guid}</guid>
-    <parent_guid>#{msg1.parent_guid}</parent_guid>
-    <parent_author_signature>#{msg1.parent_author_signature}</parent_author_signature>
-    <author_signature>#{msg1.author_signature}</author_signature>
-    <text>#{msg1.text}</text>
-    <created_at>#{msg1.created_at}</created_at>
-    <diaspora_handle>#{msg1.diaspora_id}</diaspora_handle>
-    <conversation_guid>#{msg1.conversation_guid}</conversation_guid>
-  </message>
-  <message>
-    <guid>#{msg2.guid}</guid>
-    <parent_guid>#{msg2.parent_guid}</parent_guid>
-    <parent_author_signature>#{msg2.parent_author_signature}</parent_author_signature>
-    <author_signature>#{msg2.author_signature}</author_signature>
-    <text>#{msg2.text}</text>
-    <created_at>#{msg2.created_at}</created_at>
-    <diaspora_handle>#{msg2.diaspora_id}</diaspora_handle>
-    <conversation_guid>#{msg2.conversation_guid}</conversation_guid>
-  </message>
+#{data[:messages].map {|a| a.to_xml.to_s.indent(2) }.join("\n")}
   <diaspora_handle>#{data[:diaspora_id]}</diaspora_handle>
   <participant_handles>#{data[:participant_ids]}</participant_handles>
 </conversation>

--- a/spec/lib/diaspora_federation/entities/poll_participation_spec.rb
+++ b/spec/lib/diaspora_federation/entities/poll_participation_spec.rb
@@ -8,6 +8,7 @@ module DiasporaFederation
   <guid>#{data[:guid]}</guid>
   <parent_guid>#{data[:parent_guid]}</parent_guid>
   <parent_author_signature>#{data[:parent_author_signature]}</parent_author_signature>
+  <author_signature>#{data[:author_signature]}</author_signature>
   <diaspora_handle>#{data[:diaspora_id]}</diaspora_handle>
   <poll_answer_guid>#{data[:poll_answer_guid]}</poll_answer_guid>
 </poll_participation>

--- a/spec/lib/diaspora_federation/validators/comment_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/comment_validator_spec.rb
@@ -4,22 +4,16 @@ module DiasporaFederation
 
     it_behaves_like "a common validator"
 
+    it_behaves_like "a relayable validator"
+
     it_behaves_like "a diaspora id validator" do
       let(:property) { :diaspora_id }
       let(:mandatory) { true }
     end
 
-    %i(guid parent_guid).each do |prop|
+    describe "#guid" do
       it_behaves_like "a guid validator" do
-        let(:property) { prop }
-      end
-    end
-
-    %i(author_signature parent_author_signature).each do |prop|
-      describe "##{prop}" do
-        it_behaves_like "a property that mustn't be empty" do
-          let(:property) { prop }
-        end
+        let(:property) { :guid }
       end
     end
 

--- a/spec/lib/diaspora_federation/validators/like_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/like_validator_spec.rb
@@ -3,17 +3,11 @@ module DiasporaFederation
     let(:entity) { :like_entity }
     it_behaves_like "a common validator"
 
-    %i(guid parent_guid).each do |prop|
-      it_behaves_like "a guid validator" do
-        let(:property) { prop }
-      end
-    end
+    it_behaves_like "a relayable validator"
 
-    %i(author_signature parent_author_signature).each do |prop|
-      describe "##{prop}" do
-        it_behaves_like "a property that mustn't be empty" do
-          let(:property) { prop }
-        end
+    describe "#guid" do
+      it_behaves_like "a guid validator" do
+        let(:property) { :guid }
       end
     end
 

--- a/spec/lib/diaspora_federation/validators/message_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/message_validator_spec.rb
@@ -3,22 +3,16 @@ module DiasporaFederation
     let(:entity) { :message_entity }
     it_behaves_like "a common validator"
 
+    it_behaves_like "a relayable validator"
+
     it_behaves_like "a diaspora id validator" do
       let(:property) { :diaspora_id }
       let(:mandatory) { true }
     end
 
-    %i(guid parent_guid conversation_guid).each do |prop|
+    %i(guid conversation_guid).each do |prop|
       describe "##{prop}" do
         it_behaves_like "a guid validator" do
-          let(:property) { prop }
-        end
-      end
-    end
-
-    %i(author_signature parent_author_signature).each do |prop|
-      describe "##{prop}" do
-        it_behaves_like "a property that mustn't be empty" do
           let(:property) { prop }
         end
       end

--- a/spec/lib/diaspora_federation/validators/participation_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/participation_validator_spec.rb
@@ -4,24 +4,22 @@ module DiasporaFederation
 
     it_behaves_like "a common validator"
 
+    it_behaves_like "a relayable validator"
+
     it_behaves_like "a diaspora id validator" do
       let(:property) { :diaspora_id }
       let(:mandatory) { true }
     end
 
-    %i(guid parent_guid).each do |prop|
-      describe "##{prop}" do
-        it_behaves_like "a guid validator" do
-          let(:property) { prop }
-        end
+    describe "#guid" do
+      it_behaves_like "a guid validator" do
+        let(:property) { :guid }
       end
     end
 
-    %i(target_type author_signature parent_author_signature).each do |prop|
-      describe "##{prop}" do
-        it_behaves_like "a property that mustn't be empty" do
-          let(:property) { prop }
-        end
+    describe "#target_type" do
+      it_behaves_like "a property that mustn't be empty" do
+        let(:property) { :target_type }
       end
     end
   end

--- a/spec/lib/diaspora_federation/validators/poll_participation_validator_spec.rb
+++ b/spec/lib/diaspora_federation/validators/poll_participation_validator_spec.rb
@@ -4,22 +4,18 @@ module DiasporaFederation
 
     it_behaves_like "a common validator"
 
+    it_behaves_like "a relayable validator"
+
     it_behaves_like "a diaspora id validator" do
       let(:property) { :diaspora_id }
       let(:mandatory) { true }
     end
 
-    %i(guid parent_guid poll_answer_guid).each do |prop|
+    %i(guid poll_answer_guid).each do |prop|
       describe "##{prop}" do
         it_behaves_like "a guid validator" do
           let(:property) { prop }
         end
-      end
-    end
-
-    describe "#parent_author_signature" do
-      it_behaves_like "a property that mustn't be empty" do
-        let(:property) { :parent_author_signature }
       end
     end
   end

--- a/spec/support/shared_validator_specs.rb
+++ b/spec/support/shared_validator_specs.rb
@@ -16,6 +16,14 @@ shared_examples "a common validator" do
   end
 end
 
+shared_examples "a relayable validator" do
+  describe "#parent_guid" do
+    it_behaves_like "a guid validator" do
+      let(:property) { :parent_guid }
+    end
+  end
+end
+
 shared_examples "a property with a value validation/restriction" do
   it "fails if a wrong value is supplied" do
     wrong_values.each do |val|


### PR DESCRIPTION
Introduce the "Relayable" entity, which encapsulates common properties of entities that are inherited from Relayable class in the Diaspora source code - "parent_guid", "parent_author_signature", "author_signature".